### PR TITLE
Updates Tooltip to UX-Toolkit

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "upcycle",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "homepage": "http://adsk-ui.github.io/upcycle/",
   "authors": [
     "admangum <adam.mangum@autodesk.com>"

--- a/build/themes/portal/portal.css
+++ b/build/themes/portal/portal.css
@@ -174,12 +174,65 @@
 }
 .popover.upcycle-hover_tooltip {
   background-color: #FFF;
-  border-radius: 5px;
-  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.25);
+  border-radius: 3px;
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.3);
+  padding: 8px 16px;
+  max-width: 248px;
+  border: none;
 }
+.popover.upcycle-hover_tooltip .popover-title,
 .popover.upcycle-hover_tooltip .popover-content {
-  font-family: Arial, Helvetica, sans-serif;
-  font-size: 12px;
+  font-family: inherit;
   color: #666;
-  padding: 10px;
+  padding: 0;
+  font-size: 11px;
+  line-height: 14px;
+  background-color: #FFF;
+  border-bottom: none;
+}
+.popover.upcycle-hover_tooltip .popover-title {
+  font-weight: bold;
+  margin-bottom: 4px;
+}
+.popover .arrow {
+  border-width: 11px 9px;
+}
+.popover .arrow:after {
+  border-width: 10px 8px;
+}
+.popover.top .arrow {
+  margin-left: -8px;
+  border-top-color: #EEE;
+  border-top-color: rgba(0, 0, 0, 0.08);
+}
+.popover.top .arrow:after {
+  margin-left: -8px;
+}
+.popover.right .arrow {
+  margin-top: -8px;
+  border-width: 8px 10px 8px 0;
+  border-right-color: #EEE;
+  border-right-color: rgba(0, 0, 0, 0.08);
+}
+.popover.right .arrow:after {
+  bottom: -9px;
+  border-width: 9px 11px 9px 0;
+}
+.popover.bottom .arrow {
+  margin-left: -8px;
+  border-bottom-color: #EEE;
+  border-bottom-color: rgba(0, 0, 0, 0.08);
+}
+.popover.bottom .arrow:after {
+  margin-left: -8px;
+}
+.popover.left .arrow {
+  margin-top: -8px;
+  border-width: 8px 0 8px 10px;
+  border-left-color: #EEE;
+  border-left-color: rgba(0, 0, 0, 0.08);
+}
+.popover.left .arrow:after {
+  bottom: -9px;
+  border-width: 9px 0 9px 11px;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upcycle",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "A home for our efforts to transition one-offs and semi-vetted code into a library of high quality, well tested, reusable components",
   "repository": {
     "type": "git",

--- a/test/test.css
+++ b/test/test.css
@@ -5393,14 +5393,67 @@
 }
 #sandbox .popover.upcycle-hover_tooltip {
   background-color: #FFF;
-  border-radius: 5px;
-  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.25);
+  border-radius: 3px;
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.3);
+  padding: 8px 16px;
+  max-width: 248px;
+  border: none;
 }
+#sandbox .popover.upcycle-hover_tooltip .popover-title,
 #sandbox .popover.upcycle-hover_tooltip .popover-content {
-  font-family: Arial, Helvetica, sans-serif;
-  font-size: 12px;
+  font-family: inherit;
   color: #666;
-  padding: 10px;
+  padding: 0;
+  font-size: 11px;
+  line-height: 14px;
+  background-color: #FFF;
+  border-bottom: none;
+}
+#sandbox .popover.upcycle-hover_tooltip .popover-title {
+  font-weight: bold;
+  margin-bottom: 4px;
+}
+#sandbox .popover .arrow {
+  border-width: 11px 9px;
+}
+#sandbox .popover .arrow:after {
+  border-width: 10px 8px;
+}
+#sandbox .popover.top .arrow {
+  margin-left: -8px;
+  border-top-color: #EEE;
+  border-top-color: rgba(0, 0, 0, 0.08);
+}
+#sandbox .popover.top .arrow:after {
+  margin-left: -8px;
+}
+#sandbox .popover.right .arrow {
+  margin-top: -8px;
+  border-width: 8px 10px 8px 0;
+  border-right-color: #EEE;
+  border-right-color: rgba(0, 0, 0, 0.08);
+}
+#sandbox .popover.right .arrow:after {
+  bottom: -9px;
+  border-width: 9px 11px 9px 0;
+}
+#sandbox .popover.bottom .arrow {
+  margin-left: -8px;
+  border-bottom-color: #EEE;
+  border-bottom-color: rgba(0, 0, 0, 0.08);
+}
+#sandbox .popover.bottom .arrow:after {
+  margin-left: -8px;
+}
+#sandbox .popover.left .arrow {
+  margin-top: -8px;
+  border-width: 8px 0 8px 10px;
+  border-left-color: #EEE;
+  border-left-color: rgba(0, 0, 0, 0.08);
+}
+#sandbox .popover.left .arrow:after {
+  bottom: -9px;
+  border-width: 9px 0 9px 11px;
 }
 #sandbox table.upcycle-editable,
 #sandbox .upcycle-table table {

--- a/themes/portal/less/hover_tooltip.less
+++ b/themes/portal/less/hover_tooltip.less
@@ -1,11 +1,57 @@
 .popover.upcycle-hover_tooltip {
-	.popover-content {
-	font-family: Arial, Helvetica, sans-serif;
-	font-size: 12px;
-	color: #666;
-	padding: 10px;
+	.popover-content,
+	.popover-title {
+		font-family: inherit;
+		font-size: 11px;
+		color: #666;
+		line-height: 14px;
 	}
 	background-color: #FFF;
-    border-radius: 5px;
-    box-shadow: 0 2px 4px 0 rgba(0,0,0,0.25);	
+	border-radius: 3px;
+	box-shadow: 0 2px 4px 0 rgba(0,0,0,0.30);
+	padding: 8px 16px;
+}
+
+.popover .arrow {
+	border-width: 11px 9px;
+}
+
+.popover .arrow:after {
+	border-width: 10px 8px;
+}
+
+.popover.top .arrow {
+	margin-left: -8px;
+}
+
+.popover.top .arrow:after {
+	margin-left: -8px;
+}
+
+.popover.right .arrow {
+	margin-top: -8px;
+	border-width: 8px 10px 8px 0;
+}
+
+.popover.right .arrow:after {
+	bottom: -9px;
+	border-width: 9px 11px 9px 0;
+}
+
+.popover.bottom .arrow {
+	margin-left: -8px;
+}
+
+.popover.bottom .arrow:after {
+	margin-left: -8px;
+}
+
+.popover.left .arrow {
+	margin-top: -8px;
+	border-width: 8px 0 8px 10px;
+}
+
+.popover.left .arrow:after {
+	bottom: -9px;
+	border-width: 9px 0 9px 11px;
 }

--- a/themes/portal/less/hover_tooltip.less
+++ b/themes/portal/less/hover_tooltip.less
@@ -1,14 +1,23 @@
 .popover.upcycle-hover_tooltip {
-	font-family: inherit;
-	font-size: 11px;
-	color: #666;
-	line-height: 14px;
 	background-color: #FFF;
 	border-radius: 3px;
 	box-shadow: 0 2px 4px 0 rgba(0,0,0,0.30);
 	padding: 8px 16px;
+	max-width: 248px;
+	border: none;
+	.popover-title,
+	.popover-content {
+		font-family: inherit;
+		color: #666;
+		padding: 0;
+		font-size: 11px;
+		line-height: 14px;
+		background-color: #FFF;
+		border-bottom: none;
+	}
 	.popover-title {
 		font-weight: bold;
+		margin-bottom: 4px;
 	}
 }
 
@@ -21,6 +30,8 @@
 
 .popover.top .arrow {
 	margin-left: -8px;
+	border-top-color: #EEE;
+	border-top-color: rgba(0, 0, 0, 0.08);
 	&:after {
 		margin-left: -8px;
 	}
@@ -29,6 +40,8 @@
 .popover.right .arrow {
 	margin-top: -8px;
 	border-width: 8px 10px 8px 0;
+	border-right-color: #EEE;
+	border-right-color: rgba(0, 0, 0, 0.08);
 	&:after {
 		bottom: -9px;
 		border-width: 9px 11px 9px 0;
@@ -37,6 +50,8 @@
 
 .popover.bottom .arrow {
 	margin-left: -8px;
+	border-bottom-color: #EEE;
+	border-bottom-color: rgba(0, 0, 0, 0.08);
 	&:after {
 		margin-left: -8px;
 	}
@@ -45,6 +60,8 @@
 .popover.left .arrow {
 	margin-top: -8px;
 	border-width: 8px 0 8px 10px;
+	border-left-color: #EEE;
+	border-left-color: rgba(0, 0, 0, 0.08);
 	&:after {
 		bottom: -9px;
 		border-width: 9px 0 9px 11px;

--- a/themes/portal/less/hover_tooltip.less
+++ b/themes/portal/less/hover_tooltip.less
@@ -1,57 +1,52 @@
 .popover.upcycle-hover_tooltip {
-	.popover-content,
-	.popover-title {
-		font-family: inherit;
-		font-size: 11px;
-		color: #666;
-		line-height: 14px;
-	}
+	font-family: inherit;
+	font-size: 11px;
+	color: #666;
+	line-height: 14px;
 	background-color: #FFF;
 	border-radius: 3px;
 	box-shadow: 0 2px 4px 0 rgba(0,0,0,0.30);
 	padding: 8px 16px;
+	.popover-title {
+		font-weight: bold;
+	}
 }
 
 .popover .arrow {
 	border-width: 11px 9px;
-}
-
-.popover .arrow:after {
-	border-width: 10px 8px;
+	&:after {
+		border-width: 10px 8px;
+	}
 }
 
 .popover.top .arrow {
 	margin-left: -8px;
-}
-
-.popover.top .arrow:after {
-	margin-left: -8px;
+	&:after {
+		margin-left: -8px;
+	}
 }
 
 .popover.right .arrow {
 	margin-top: -8px;
 	border-width: 8px 10px 8px 0;
-}
-
-.popover.right .arrow:after {
-	bottom: -9px;
-	border-width: 9px 11px 9px 0;
+	&:after {
+		bottom: -9px;
+		border-width: 9px 11px 9px 0;
+	}
 }
 
 .popover.bottom .arrow {
 	margin-left: -8px;
-}
-
-.popover.bottom .arrow:after {
-	margin-left: -8px;
+	&:after {
+		margin-left: -8px;
+	}
 }
 
 .popover.left .arrow {
 	margin-top: -8px;
 	border-width: 8px 0 8px 10px;
-}
-
-.popover.left .arrow:after {
-	bottom: -9px;
-	border-width: 9px 0 9px 11px;
+	&:after {
+		bottom: -9px;
+		border-width: 9px 0 9px 11px;
+	}
 }


### PR DESCRIPTION
WHAT
Updates the look and feel of our tooltips to match new UX by overriding Bootstrap.
--border-radius:3px; 
--font-size:11px; 
--padding:8px 16px; 
--drop shadow: 0px 2px 4px 0px rgba(0,0,0,0.30)
--tooltip arrow is 10x16

Please review, but don't merge. If code is good, I will cut a new release in this branch.