### PR TITLE
Fix for AUM Tooltips

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "upcycle",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "homepage": "http://adsk-ui.github.io/upcycle/",
   "authors": [
     "admangum <adam.mangum@autodesk.com>"

--- a/build/themes/portal/portal.css
+++ b/build/themes/portal/portal.css
@@ -187,7 +187,6 @@
   padding: 0;
   font-size: 11px;
   line-height: 14px;
-  background-color: #FFF;
   border-bottom: none;
 }
 .popover.upcycle-hover_tooltip .popover-title {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upcycle",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "A home for our efforts to transition one-offs and semi-vetted code into a library of high quality, well tested, reusable components",
   "repository": {
     "type": "git",

--- a/test/test.css
+++ b/test/test.css
@@ -5406,7 +5406,6 @@
   padding: 0;
   font-size: 11px;
   line-height: 14px;
-  background-color: #FFF;
   border-bottom: none;
 }
 #sandbox .popover.upcycle-hover_tooltip .popover-title {

--- a/themes/portal/less/hover_tooltip.less
+++ b/themes/portal/less/hover_tooltip.less
@@ -12,7 +12,6 @@
 		padding: 0;
 		font-size: 11px;
 		line-height: 14px;
-		background-color: #FFF;
 		border-bottom: none;
 	}
 	.popover-title {


### PR DESCRIPTION
WHAT
Removes the background color on the title and content section for tooltips. This background was over writing the border radius of the whole tooltip.